### PR TITLE
Fix Vercel preview asset paths

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -2,11 +2,12 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { fileURLToPath, URL } from "node:url";
 
+const productionBase = process.env.VERCEL ? "/" : "/portfolio/";
+
 export default defineConfig(({ command }) => ({
-	// Keep production assets isolated from the other projects sharing the
-	// domain document root. The development server remains root-based so its
-	// SPA fallback handles local routes such as /contact.
-	base: command === "build" ? "/portfolio/" : "/",
+	// Vercel previews own their domain root. Hostinger production shares its
+	// document root, so its assets remain isolated under /portfolio/.
+	base: command === "build" ? productionBase : "/",
 	plugins: [react({ include: /\.[jt]sx?$/ })],
 	resolve: {
 		alias: {


### PR DESCRIPTION
## Summary
- use root asset paths for Vercel builds
- retain the `/portfolio/` asset base for Hostinger production
- keep the development server rooted at `/`

## Verification
- `VERCEL=1 yarn build` emits `/assets/...` and `/manifest.json`
- `yarn build` retains `/portfolio/assets/...`
- `yarn test` passes all 4 tests
- deployed Vercel preview loads with zero console errors and all first-party assets return HTTP 200