### PR TITLE
feat: add experimental WebMCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # [akashraj.tech ](https://akashraj.tech)
 
+## Experimental WebMCP support
+
+Browsers that expose the experimental `navigator.modelContext` API can discover and call portfolio tools for:
+
+- reading a portfolio overview;
+- searching projects and their links;
+- retrieving structured resume data;
+- finding public contact options; and
+- navigating between portfolio sections.
+
+The integration is feature-detected, so browsers without WebMCP support continue to use the site normally.
+
 > ---
 >
 > ## This is a project to port my website orignally in `PHP` to `React`

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import Resume from "./pages/Resume";
 import Contact from "./pages/Contact";
 import Stats from "./pages/Stats";
 import { SoundProvider } from "./logic/audio/SoundProvider";
+import WebMcpProvider from "./logic/webmcp/WebMcpProvider";
 
 const AnimatedRoutes = () => {
 	const location = useLocation();
@@ -20,15 +21,17 @@ const AnimatedRoutes = () => {
 	return (
 		<TransitionGroup component={null}>
 			<CSSTransition nodeRef={nodeRef} key={location.pathname.split("/")[1] || "/"} timeout={{ enter: 300, exit: 200 }} classNames='fade'>
-				<div ref={nodeRef}><Routes location={location}>
-					<Route path='/' element={<Home />} />
-					<Route path='/lab' element={<Work />} />
-					<Route path='/work' element={<Work />} />
-					<Route path='/resume' element={<Resume />} />
-					<Route path='/contact' element={<Contact />} />
-					<Route path='/stats' element={<Stats />} />
-					<Route path='*' element={<>404 Page not found</>} />
-				</Routes></div>
+				<div ref={nodeRef}>
+					<Routes location={location}>
+						<Route path='/' element={<Home />} />
+						<Route path='/lab' element={<Work />} />
+						<Route path='/work' element={<Work />} />
+						<Route path='/resume' element={<Resume />} />
+						<Route path='/contact' element={<Contact />} />
+						<Route path='/stats' element={<Stats />} />
+						<Route path='*' element={<>404 Page not found</>} />
+					</Routes>
+				</div>
 			</CSSTransition>
 		</TransitionGroup>
 	);
@@ -49,10 +52,14 @@ export const App = () => {
 		<div className={`App`}>
 			<SoundProvider>
 				<Router>
-					<ScrollToTop />
-					<Header />
-					<div id='main' className='main-content'><AnimatedRoutes /></div>
-					<Footer />
+					<WebMcpProvider>
+						<ScrollToTop />
+						<Header />
+						<div id='main' className='main-content'>
+							<AnimatedRoutes />
+						</div>
+						<Footer />
+					</WebMcpProvider>
 				</Router>
 			</SoundProvider>
 		</div>

--- a/src/logic/webmcp/WebMcpProvider.jsx
+++ b/src/logic/webmcp/WebMcpProvider.jsx
@@ -1,0 +1,177 @@
+import React, { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { basic, contact, home, work } from "data";
+import resumeData from "data/resume.json";
+
+const emptyInputSchema = {
+	type: "object",
+	properties: {},
+	additionalProperties: false,
+};
+
+const pageRoutes = {
+	home: "/",
+	projects: "/lab",
+	stats: "/stats",
+	resume: "/resume",
+	contact: "/contact",
+};
+
+const portfolioOwner = resumeData.basics.name || basic.name;
+
+const textResult = (value) => ({
+	content: [
+		{
+			type: "text",
+			text: JSON.stringify(value),
+		},
+	],
+});
+
+const projectDetails = ({ name, link_code, link_live }) => ({
+	name,
+	liveUrl: link_live || null,
+	sourceUrl: link_code || null,
+});
+
+export const createWebMcpTools = ({ navigate }) => [
+	{
+		name: "get_portfolio_overview",
+		description: `Get a concise overview of ${portfolioOwner}, current work, and the sections available on this portfolio.`,
+		inputSchema: emptyInputSchema,
+		execute: () =>
+			textResult({
+				name: portfolioOwner,
+				headline: home.heading,
+				summary: resumeData.basics.summary,
+				currentCompany: {
+					name: basic.currentCompany,
+					url: basic.currentCompanyLink,
+				},
+				website: basic.fullWebsite,
+				availableSections: Object.keys(pageRoutes),
+			}),
+	},
+	{
+		name: "search_portfolio_projects",
+		description: `List or search the projects and experiments in ${portfolioOwner}'s portfolio, including live and source-code links.`,
+		inputSchema: {
+			type: "object",
+			properties: {
+				query: {
+					type: "string",
+					description: "Optional case-insensitive text to match against project names.",
+				},
+				limit: {
+					type: "integer",
+					minimum: 1,
+					maximum: 15,
+					default: 15,
+					description: "Maximum number of projects to return.",
+				},
+			},
+			additionalProperties: false,
+		},
+		execute: ({ query = "", limit = 15 } = {}) => {
+			const normalizedQuery = query.trim().toLowerCase();
+			const normalizedLimit = Math.min(Math.max(Number(limit) || 15, 1), 15);
+			const projects = work.projects
+				.filter(({ name }) => name.toLowerCase().includes(normalizedQuery))
+				.slice(0, normalizedLimit)
+				.map(projectDetails);
+
+			return textResult({ query, count: projects.length, projects });
+		},
+	},
+	{
+		name: "get_portfolio_resume",
+		description: `Get structured resume information for ${portfolioOwner}, optionally limited to one resume section.`,
+		inputSchema: {
+			type: "object",
+			properties: {
+				section: {
+					type: "string",
+					enum: ["all", "basics", "experience", "projects", "education", "skills"],
+					default: "all",
+					description: "The resume section to return.",
+				},
+			},
+			additionalProperties: false,
+		},
+		execute: ({ section = "all" } = {}) => {
+			if (section === "all") return textResult(resumeData);
+			return textResult({ [section]: resumeData[section] });
+		},
+	},
+	{
+		name: "get_portfolio_contact_options",
+		description: `Get the public ways to contact or follow ${portfolioOwner}. This tool does not send a message or open an external site.`,
+		inputSchema: emptyInputSchema,
+		execute: () =>
+			textResult({
+				email: contact.email,
+				contactForm: contact.contact_form,
+				socialProfiles: contact.socials.map(({ name, link }) => ({ name, url: link })),
+			}),
+	},
+	{
+		name: "navigate_portfolio",
+		description: `Navigate the current portfolio tab to a named section. This only changes pages within ${basic.website}.`,
+		inputSchema: {
+			type: "object",
+			properties: {
+				section: {
+					type: "string",
+					enum: Object.keys(pageRoutes),
+					description: "Portfolio section to open.",
+				},
+			},
+			required: ["section"],
+			additionalProperties: false,
+		},
+		execute: ({ section } = {}) => {
+			const path = pageRoutes[section];
+			if (!path) return textResult({ success: false, error: "Unknown portfolio section." });
+
+			navigate(path);
+			return textResult({ success: true, section, path });
+		},
+	},
+];
+
+export const registerWebMcpTools = (tools, modelContext = globalThis.navigator?.modelContext) => {
+	if (typeof modelContext?.registerTool !== "function") return () => {};
+
+	const registeredToolNames = [];
+
+	tools.forEach((tool) => {
+		try {
+			modelContext.registerTool(tool);
+			registeredToolNames.push(tool.name);
+		} catch (error) {
+			console.warn(`Unable to register WebMCP tool: ${tool.name}`, error);
+		}
+	});
+
+	return () => {
+		if (typeof modelContext.unregisterTool !== "function") return;
+
+		registeredToolNames.forEach((toolName) => {
+			try {
+				modelContext.unregisterTool(toolName);
+			} catch (error) {
+				console.warn(`Unable to unregister WebMCP tool: ${toolName}`, error);
+			}
+		});
+	};
+};
+
+const WebMcpProvider = ({ children }) => {
+	const navigate = useNavigate();
+
+	useEffect(() => registerWebMcpTools(createWebMcpTools({ navigate })), [navigate]);
+
+	return children;
+};
+
+export default WebMcpProvider;

--- a/src/logic/webmcp/WebMcpProvider.test.jsx
+++ b/src/logic/webmcp/WebMcpProvider.test.jsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import resumeData from "data/resume.json";
+import WebMcpProvider, { createWebMcpTools, registerWebMcpTools } from "./WebMcpProvider";
+
+const parseResult = (result) => JSON.parse(result.content[0].text);
+
+describe("WebMCP portfolio tools", () => {
+	test("derives owner details from resume data", () => {
+		const tools = createWebMcpTools({ navigate: vi.fn() });
+		const overview = tools.find(({ name }) => name === "get_portfolio_overview");
+		const result = parseResult(overview.execute());
+
+		expect(result.name).toBe(resumeData.basics.name);
+		expect(result.summary).toBe(resumeData.basics.summary);
+		expect(overview.description).toContain(resumeData.basics.name);
+	});
+
+	test("registers tools while the provider is mounted", () => {
+		const modelContext = {
+			registerTool: vi.fn(),
+			unregisterTool: vi.fn(),
+		};
+		Object.defineProperty(window.navigator, "modelContext", {
+			configurable: true,
+			value: modelContext,
+		});
+
+		const { unmount } = render(
+			<MemoryRouter>
+				<WebMcpProvider>
+					<p>Portfolio</p>
+				</WebMcpProvider>
+			</MemoryRouter>,
+		);
+
+		expect(modelContext.registerTool).toHaveBeenCalledTimes(5);
+		unmount();
+		expect(modelContext.unregisterTool).toHaveBeenCalledTimes(5);
+		delete window.navigator.modelContext;
+	});
+
+	test("registers and unregisters every tool", () => {
+		const modelContext = {
+			registerTool: vi.fn(),
+			unregisterTool: vi.fn(),
+		};
+		const tools = createWebMcpTools({ navigate: vi.fn() });
+
+		const unregister = registerWebMcpTools(tools, modelContext);
+		unregister();
+
+		expect(modelContext.registerTool).toHaveBeenCalledTimes(tools.length);
+		expect(modelContext.unregisterTool).toHaveBeenCalledTimes(tools.length);
+		expect(modelContext.unregisterTool).toHaveBeenCalledWith("get_portfolio_overview");
+	});
+
+	test("is a no-op in browsers without WebMCP support", () => {
+		const unregister = registerWebMcpTools(createWebMcpTools({ navigate: vi.fn() }), undefined);
+
+		expect(unregister).toBeTypeOf("function");
+		expect(() => unregister()).not.toThrow();
+	});
+
+	test("searches projects and returns machine-readable links", () => {
+		const tools = createWebMcpTools({ navigate: vi.fn() });
+		const searchProjects = tools.find(({ name }) => name === "search_portfolio_projects");
+
+		const result = parseResult(searchProjects.execute({ query: "git", limit: 1 }));
+
+		expect(result.count).toBe(1);
+		expect(result.projects[0]).toMatchObject({
+			name: "Git - Stats",
+			liveUrl: "https://gitstats.me",
+			sourceUrl: "https://github.com/akashraj9828/gitstats",
+		});
+	});
+
+	test("navigates only to a known portfolio section", () => {
+		const navigate = vi.fn();
+		const tools = createWebMcpTools({ navigate });
+		const navigatePortfolio = tools.find(({ name }) => name === "navigate_portfolio");
+
+		expect(parseResult(navigatePortfolio.execute({ section: "projects" }))).toEqual({
+			success: true,
+			section: "projects",
+			path: "/lab",
+		});
+		expect(parseResult(navigatePortfolio.execute({ section: "elsewhere" }))).toEqual({
+			success: false,
+			error: "Unknown portfolio section.",
+		});
+		expect(navigate).toHaveBeenCalledOnce();
+		expect(navigate).toHaveBeenCalledWith("/lab");
+	});
+});


### PR DESCRIPTION
## Summary

- register feature-detected experimental WebMCP portfolio tools
- expose overview, project search, resume, contact, and internal navigation capabilities
- derive owner-specific values from existing portfolio and resume data
- document the experimental integration

## Validation

- yarn test (10 tests passed)
- yarn build
- git diff --check